### PR TITLE
marshal segment rules

### DIFF
--- a/segment/resource_segment_tracking_plan.go
+++ b/segment/resource_segment_tracking_plan.go
@@ -54,9 +54,12 @@ func resourceSegmentTrackingPlanRead(r *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-
+	stringRules, err := json.Marshal(trackingPlan.Rules)
+	if err != nil {
+		return err
+	}
 	r.Set("display_name", trackingPlan.DisplayName)
-	r.Set("rules", trackingPlan.Rules)
+	r.Set("rules", string(stringRules))
 
 	return nil
 }


### PR DESCRIPTION
Bug fixed where a user changes a segment protocol rule on the web app, and terraform does not recognize the changes.  The fix was to correctly store the stringRules variable as a jsonstring.